### PR TITLE
SwiftLint 0.58.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:swift-5
+FROM norionomura/swiftlint:0.58.2
 LABEL version="3.2.1"
 LABEL repository="https://github.com/norio-nomura/action-swiftlint"
 LABEL homepage="https://github.com/norio-nomura/action-swiftlint"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,5 +41,4 @@ then
 	fi
 fi
 
-set -o pipefail && swiftlint --version
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands | parseOutputsParameters

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,4 +41,5 @@ then
 	fi
 fi
 
+set -o pipefail && swiftlint --version
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands | parseOutputsParameters


### PR DESCRIPTION
Use the SwiftLint 0.58.2 Docker container rather than allowing to use the latest Swift 5 container